### PR TITLE
[codex] add project maintenance vault

### DIFF
--- a/psi/.gitignore
+++ b/psi/.gitignore
@@ -1,0 +1,5 @@
+data/
+**/origin
+*.db
+*.sqlite
+*.sqlite3

--- a/psi/README.md
+++ b/psi/README.md
@@ -1,0 +1,27 @@
+# Project Maintenance Vault
+
+This `psi/` directory is for maintaining the `oracle-step-by-step` repository.
+It is not part of the Oracle workspace that this guide helps users create.
+
+The guide still teaches users to create their own Oracle brain vault. This
+maintainer vault records work on this teaching repo: handoffs, decisions,
+readouts, and project-specific learnings.
+
+## Rules
+
+- GitHub Issues and pull requests are the durable queue.
+- This vault is memory and handoff, not a task claim system.
+- Do not store secrets, tokens, API keys, generated databases, or runtime state.
+- Keep user-facing setup instructions in `README.md` and `steps/`.
+- Use this vault only for project maintenance context.
+
+## Structure
+
+```text
+psi/
+  active/     current maintainer context and checkpoints
+  handoff/    session handoffs for future maintainers
+  decisions/  project decisions, reversals, and rationale
+  learn/      repo readouts, proofs, and investigations
+  memory/     durable project learnings and retrospectives
+```

--- a/psi/active/README.md
+++ b/psi/active/README.md
@@ -1,0 +1,6 @@
+# Active
+
+Current maintainer context and checkpoints for this repository.
+
+Use this for short-lived orientation notes. Durable tasks belong in GitHub
+Issues or pull requests.

--- a/psi/decisions/README.md
+++ b/psi/decisions/README.md
@@ -1,0 +1,6 @@
+# Decisions
+
+Project decisions, reversals, and rationale.
+
+Use this when a choice changes how the teaching guide is maintained or how the
+repo should be operated.

--- a/psi/handoff/README.md
+++ b/psi/handoff/README.md
@@ -1,0 +1,6 @@
+# Handoff
+
+Session handoffs for future maintainers of this repository.
+
+Write what changed, what was verified, what remains open, and where the durable
+GitHub issue or pull request lives.

--- a/psi/learn/README.md
+++ b/psi/learn/README.md
@@ -1,0 +1,5 @@
+# Learn
+
+Readouts, proofs, and investigations about this repository.
+
+Use this for repo-specific research that should survive a single session.

--- a/psi/memory/README.md
+++ b/psi/memory/README.md
@@ -1,0 +1,5 @@
+# Memory
+
+Durable project learnings and retrospectives for maintainers.
+
+Do not store generated Oracle memory databases or user workspace content here.


### PR DESCRIPTION
## Summary

Adds a minimal `psi/` project-maintenance vault for the `oracle-step-by-step` repository.

This is intentionally not a user Oracle workspace. The new root `psi/README.md` says the guide still teaches users to create their own Oracle brain vault, while this maintainer vault is only for repository maintenance handoffs, decisions, readouts, and project-specific learnings.

## Why

This is the first small SBS repo rollout pilot from `oracle-mother` issue #9. It applies the control-vault/project-vault split without touching runtime services, secrets, generated databases, or multi-agent scheduling.

## Validation

- `git diff --check`
- staged diff reviewed locally
- branch pushed from fork `natkingsize2/oracle-step-by-step`

## Notes

No `maw team` or scheduler work was started. This PR is draft so maintainers can confirm whether this project-maintenance vault shape belongs in the teaching repo.
